### PR TITLE
boolean pop out chat windows on notification click flag

### DIFF
--- a/js/manifest.js
+++ b/js/manifest.js
@@ -11,8 +11,12 @@ fin.desktop.Application.getCurrent().getManifest(function (manifest) {
       window.localStorage.setItem('notificationsVersion', "V2");
       window.localStorage.setItem('notificationsHeight', 60);
     }
+	
+    let popoutChatNotificationFlag = manifest.startup_app.customData.popoutChatOnNotificationClick;
+    if (typeof popoutChatNotificationFlag !== 'undefined') {
+      window.localStorage.setItem('popoutChatNotification', popoutChatNotificationFlag);
+    }
   }
-  
 });
 
 if (window.localStorage.getItem('notificationsLocation') === null) {

--- a/js/notify.js
+++ b/js/notify.js
@@ -282,17 +282,40 @@ class Notify {
     addEventListener(event, cb) {
       var notificationsVersion = window.localStorage.getItem('notificationsVersion')
       var notificationName = this.notification.name
+      let popoutFunctionality = function(data) {
+        let popoutChat = window.localStorage.getItem('popoutChatNotification');
+        if (popoutChat === 'true') {
+          let waitForElement = (elementId, count, cb) => {
+            let element = document.getElementById(elementId);  
+            if(element) {            
+              cb(element);
+            } else {
+              if(count<15) {
+                count++;
+                setTimeout(()=>waitForElement(elementId, count, cb),450)
+              }
+            }
+          };
+          let divId = 'im' + data.streamId.replace(/\W/g, '');
+          waitForElement(divId, 0, () => {
+            let popoutIcon = document.getElementsByClassName('enhanced-pop-out')[0];
+            popoutIcon.click();
+          });
+        }
+      }
       if (notificationsVersion === "V1") {
         if(event === 'click' && this.notification) {
             this.notification.noteWin.onClick = () => {
-                if (this.sticky) {
-                    this.notification.close();                    
-                }
+            popoutFunctionality(this._data);
+            if (this.sticky) {
+              this.notification.close();                    
+            }
                 cb({target:{callbackJSON:this._data}}); 
             }
         }
       } else if (notificationsVersion === "V2") {        
         if (event === 'click') {
+popoutFunctionality(this._data);
           // On click of the body of the notification, the notification window is set to minimize, 
           // but on click of the "X", it closes. That way, we can choose to dismiss 
           // notifications instead of always directing to the chat window.

--- a/js/notify.js
+++ b/js/notify.js
@@ -299,7 +299,10 @@ class Notify {
           let divId = 'im' + data.streamId.replace(/\W/g, '');
           waitForElement(divId, 0, () => {
             let popoutIcon = document.getElementsByClassName('enhanced-pop-out')[0];
-            popoutIcon.click();
+            let inMainWindow = !window.location.pathname.includes('float');
+            if (popoutIcon && inMainWindow) {
+              popoutIcon.click();
+            }
           });
         }
       }

--- a/public/app.json
+++ b/public/app.json
@@ -17,7 +17,8 @@
         "saveWindowState": false,
         "preload": "https://cdn.openfin.co/demos/symphony-of/bundle.js",
         "customData": {
-          "symphonyNotifications": "V2"
+          "symphonyNotifications": "V2",
+          "popoutChatOnNotificationClick": false
         }
     },
     "runtime": {


### PR DESCRIPTION
Adds the popoutChatOnNotificationClick flag to the customData section of the manifest. true will cause chat windows to pop out into individual windows on notification click. Symphony still enforces the 5 chat popout limit.