### PR TITLE
SYMPH-87 change conditional load logic to use global/parent window

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -10,7 +10,7 @@ window.addEventListener('load', () => {
     let currentWindow = fin.desktop.Window.getCurrent();
     let application = fin.desktop.Application.getCurrent();
 
-    if(currentWindow.uuid===currentWindow.name && !window.once) {
+    if(currentWindow.uuid===currentWindow.name && !parent.once) {
         //navigate to converation from main window on notification click
         window.popouts = JSON.parse(window.localStorage.getItem('wins')) || {};
 


### PR DESCRIPTION
The `parent` variable accesses the global parent window, whereas the `window` variable only looks at the iframe's window. The code in the `if` statement was executing on every chat click. 