### PR TITLE
Listen to download events on current app instead of current window

### DIFF
--- a/js/download-bar.js
+++ b/js/download-bar.js
@@ -1,12 +1,14 @@
 window.once2 = false;
 
 window.addEventListener('load', () => {
+    const app = fin.desktop.Application.getCurrent();
     const currentWindow = fin.desktop.Window.getCurrent();
 
     if (currentWindow.uuid === currentWindow.name && !parent.once2) {
+        window.once2 = true;
 
         // Add download item to the download bar when a file starts downloading
-        currentWindow.addEventListener('file-download-started', (downloadEvt) => {
+        app.addEventListener('window-file-download-started', (downloadEvt) => {
             if (!downloadEvt.mimeType.includes('image')) {
                 initiate();
                 createDOM(downloadEvt);
@@ -16,7 +18,7 @@ window.addEventListener('load', () => {
         });
 
         // Update download completion percentage while download progresses
-        currentWindow.addEventListener('file-download-progress', (downloadEvt) => {
+        app.addEventListener('window-file-download-progress', (downloadEvt) => {
             const downloadItemKey = `uuid-${downloadEvt.fileUuid}`;
             const downloadItem = document.querySelector(`#${downloadItemKey}`);
             const fileProgressTitle = downloadItem.querySelector('#per');
@@ -27,7 +29,7 @@ window.addEventListener('load', () => {
             console.log('file download progress event registered');
         });
 
-        currentWindow.addEventListener('file-download-completed', (downloadEvt) => {
+        app.addEventListener('window-file-download-completed', (downloadEvt) => {
             const { fileUuid } = downloadEvt;
             const downloadItemKey = `uuid-${fileUuid}`;
             const downloadItem = document.querySelector(`#${downloadItemKey}`);
@@ -169,5 +171,4 @@ window.addEventListener('load', () => {
             }
         }
     }
-    window.once2 = true;
 });

--- a/public/app.json
+++ b/public/app.json
@@ -21,10 +21,15 @@
             "symphonyNotifications": "V2",
             "popoutChatOnNotificationClick": false
         },
-        "spellCheck": true
+        "spellCheck": true,
+        "experimental": {
+            "api": {
+                "fileDownloadApi": true
+            }
+        }
     },
     "runtime": {
-        "arguments": "--noerrdialogs --frameStrategy=frames --enable-aggressive-domstorage-flushing --winhttp-proxy-resolver --get-download-events",
+        "arguments": "--noerrdialogs --frameStrategy=frames --enable-aggressive-domstorage-flushing --winhttp-proxy-resolver",
         "version": "9.61.34.22",
         "fallbackVersion": "8.56.30.57"
     },


### PR DESCRIPTION
Now download events are being added to the app instead of current window, so it will listen to download events from all windows in the main app.

Also, updated the runtime version to 9.61.34.23 which contains the download events API, and also added the property to enable this feature in the app config:

```
        "experimental": {
            "api": {
                "fileDownloadApi": true
            }
        }
```