### PR TITLE
SYMPH-115_popout-window-close-on-download-completion

### DIFF
--- a/js/download-bar.js
+++ b/js/download-bar.js
@@ -64,12 +64,6 @@ window.addEventListener('load', () => {
 
                 openFile(fileUuid);
             }
-
-            if (downloadEvt.name !== app.getWindow().name) {
-                const dlWin = fin.desktop.Window.wrap(app.uuid, downloadEvt.name);
-                dlWin.close();
-            }
-
         }, () => {
             console.log('file download completed event registered');
         });


### PR DESCRIPTION
Removed the temporary fix for closing renderers opened by downloads since it was closing popout windows. The full fix will come in runtime `9.61.36.*.`