### PR TITLE
SYMPH-117 Downloaded items are not removed from download bar on click now

### DIFF
--- a/js/download-bar.js
+++ b/js/download-bar.js
@@ -56,10 +56,6 @@ window.addEventListener('load', () => {
 
                 itemDiv.addEventListener('click', () => {
                     openFile(fileUuid);
-                    downloadItem.remove();
-                    if (!downloadMain.hasChildNodes()) {
-                        mainFooter.classList.add('hidden');
-                    }
                 });
 
                 openFile(fileUuid);


### PR DESCRIPTION
Downloaded items will now stay on the download bar until the bar is closed. A click only opens the file, but does not remove it.