### PR TITLE
Removed close force true for popouts

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -54,7 +54,7 @@ window.addEventListener('load', () => {
                 const closeArr = t.target.closest('.close-module');
 
                 if (popInBtn || closeArr) {
-                    currentWindow.close(true);
+                    currentWindow.close();
                 }
 
             }, true);


### PR DESCRIPTION
In Windows 10, when hitting the X button next to the pop-in button makes the application freeze, by removing close force true for poputs it magically works. 